### PR TITLE
Fix LcFirst bug with leading multi-byte character. Addresses #8

### DIFF
--- a/stringy.go
+++ b/stringy.go
@@ -180,10 +180,10 @@ func (i *input) Last(length int) string {
 // function which return StringManipulation interface
 func (i *input) LcFirst() string {
 	input := getInput(*i)
-	for i, v := range input {
-		return string(unicode.ToLower(v)) + input[i+1:]
+	for _, v := range input {
+		return string(unicode.ToLower(v)) + input[len(string(v)):]
 	}
-	return input
+	return ""
 }
 
 // Lines returns slice of strings by removing white space characters

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -123,18 +123,29 @@ func TestInput_KebabCase(t *testing.T) {
 }
 
 func TestInput_LcFirst(t *testing.T) {
-	str := New("This is an all lower")
-	against := "this is an all lower"
-	if val := str.LcFirst(); val != against {
-		t.Errorf("Expected: to be %s but got: %s", against, val)
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "leading uppercase",
+			arg:  "This is an all lower",
+			want: "this is an all lower",
+		},
+		{
+			name: "empty string",
+			arg:  "",
+			want: "",
+		},
 	}
-}
 
-func TestInput_LcFirstEmpty(t *testing.T) {
-	str := New("")
-	against := ""
-	if val := str.LcFirst(); val != against {
-		t.Errorf("Expected: to be %s but got: %s", against, val)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.arg).LcFirst(); got != tt.want {
+				t.Errorf("LcFirst(%v) = %v, want %v", tt.arg, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -138,6 +138,11 @@ func TestInput_LcFirst(t *testing.T) {
 			arg:  "",
 			want: "",
 		},
+		{
+			name: "multi-byte leading character",
+			arg:  "ΔΔΔ",
+			want: "δΔΔ",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Leading multi-byte characters no longer cause duplicated bytes in LcFirst().

Fixes #8 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran go test ./...

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules