### PR TITLE
UcFirst accounts for multi-byte leading characters. Addresses #10 

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -59,8 +59,8 @@ func replaceStr(input, search, replace, types string) string {
 }
 
 func ucfirst(val string) string {
-	for i, v := range val {
-		return string(unicode.ToUpper(v)) + val[i+1:]
+	for _, v := range val {
+		return string(unicode.ToUpper(v)) + val[len(string(v)):]
 	}
 	return ""
 }

--- a/stringy.go
+++ b/stringy.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 )
 
-// input is struct that holds input form user and result
+// input is struct that holds input from user and result
 type input struct {
 	Input  string
 	Result string

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -276,18 +276,34 @@ func TestInput_TeaseEmpty(t *testing.T) {
 }
 
 func TestInput_UcFirst(t *testing.T) {
-	str := New("this is test")
-	against := "This is test"
-	if val := str.UcFirst(); val != against {
-		t.Errorf("Expected: to be %s but got: %s", against, val)
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "leading lowercase",
+			arg:  "test input",
+			want: "Test input",
+		},
+		{
+			name: "empty string",
+			arg:  "",
+			want: "",
+		},
+		{
+			name: "multi-byte leading character",
+			arg:  "δδδ",
+			want: "Δδδ",
+		},
 	}
-}
 
-func TestInput_EmptyUcFirst(t *testing.T) {
-	str := New("")
-	against := ""
-	if val := str.UcFirst(); val != against {
-		t.Errorf("Expected: to be %s but got: %s", against, val)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.arg).UcFirst(); got != tt.want {
+				t.Errorf("UcFirst(%v) = %v, want %v", tt.arg, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Description

Similar to recent LcFirst patch, account for multi-byte leading characters in UcFirst without duplicating bytes.

Fixes #10 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

go test ./...

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules