### PR TITLE
Treat "true" as a valid boolean

### DIFF
--- a/message.go
+++ b/message.go
@@ -18,4 +18,4 @@ const (
 var False = []string{"off", "no", "0", "false"}
 
 // True is slice of array for true logical representation in string
-var True = []string{"on", "yes", "1", "True"}
+var True = []string{"on", "yes", "1", "true"}

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -29,33 +29,42 @@ func TestInput_EmptyNoMatchBetween(t *testing.T) {
 	}
 }
 
-func TestInput_Boolean(t *testing.T) {
-	str := New("on")
-	val := str.Boolean()
-	if !val {
-		t.Errorf("Expected: to be true but got: %v", val)
+func TestInput_BooleanTrue(t *testing.T) {
+	strs := []string{"on", "On", "yes", "YES", "1", "true"}
+	for _, s := range strs {
+		t.Run(s, func(t *testing.T) {
+			if val := New(s).Boolean(); !val {
+				t.Errorf("Expected: to be true but got: %v", val)
+			}
+		})
 	}
 }
 
-func TestInput_BooleanOff(t *testing.T) {
-	str := New("off")
-	val := str.Boolean()
-	if val {
-		t.Errorf("Expected: to be false but got: %v", val)
+func TestInput_BooleanFalse(t *testing.T) {
+	strs := []string{"off", "Off", "no", "NO", "0", "false"}
+	for _, s := range strs {
+		t.Run(s, func(t *testing.T) {
+			if val := New(s).Boolean(); val {
+				t.Errorf("Expected: to be false but got: %v", val)
+			}
+		})
 	}
 }
 
 func TestInput_BooleanError(t *testing.T) {
-	defer func() {
-		if err := recover(); err == nil {
-			t.Errorf("Error expected")
-		}
-	}()
-	str := New("invalid")
-	val := str.Boolean()
-	if val {
-		t.Errorf("Expected: to be false but got: %v", val)
+	strs := []string{"invalid", "-1", ""}
+	for _, s := range strs {
+		t.Run(s, func(t *testing.T) {
+			defer func() {
+				if err := recover(); err == nil {
+					t.Errorf("Error expected")
+				}
+			}()
+			val := New(s).Boolean()
+			t.Errorf("Expected: to panic but got: %v", val)
+		})
 	}
+
 }
 
 func TestInput_CamelCase(t *testing.T) {


### PR DESCRIPTION
# Description

"true" / "True" etc. are not treated as valid Boolean strings, because the value "True"
is not lowercased in the `True` slice.

Fixes issue #14:

- Expand test cases for Boolean
- Properly test for boolean "true"

Behavior can be seen at: https://go.dev/play/p/YZ2SqgZTmOp

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests to improve valid and invalid boolean value testing, and ran `go test`.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
