### PR TITLE
API consistency and PascalCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Convert string to camel case, snake case, kebab case / slugify, custom delimiter
          <td><a href="#acronym-string">Acronym</a></td>
         <td><a href="#title-string">Title</a></td>
      </tr>
+     <tr>
+         <td><a href="#pascalcaserule-string-string">PascalCase</a></td>
+         <td></td>
+        <td></td>
+     </tr>
 </table>
 
 
@@ -124,13 +129,13 @@ CamelCase is variadic function which takes one Param rule i.e slice of strings a
 
 ```go
   camelCase := stringy.New("ThisIsOne___messed up string. Can we Really camel-case It ?##")
-  fmt.Println(camelCase.CamelCase("?", "", "#", "")) // ThisIsOneMessedUpStringCanWeReallyCamelCaseIt
+  fmt.Println(camelCase.CamelCase("?", "", "#", "")) // thisIsOneMessedUpStringCanWeReallyCamelCaseIt
 ```
 look how it omitted ?## from string. If you dont want to omit anything and since it returns plain strings and you cant actually cap all or lower case all camelcase string its not required.
 
 ```go
   camelCase := stringy.New("ThisIsOne___messed up string. Can we Really camel-case It ?##")
-  fmt.Println(camelCase.CamelCase()) // ThisIsOneMessedUpStringCanWeReallyCamelCaseIt?##
+  fmt.Println(camelCase.CamelCase()) // thisIsOneMessedUpStringCanWeReallyCamelCaseIt?##
 ```
 
 #### ContainsAll(check ...string) bool
@@ -373,6 +378,21 @@ Acronym func returns acronym of input string. You can chain ToUpper() which with
 ```go
   acronym := stringy.New("Laugh Out Loud")
 	fmt.Println(acronym.Acronym().ToLower()) // lol
+```
+
+#### PascalCase(rule ...string) string
+
+PascalCase is variadic function which takes one Param rule i.e slice of strings and it returns input type string in pascal case form and rule helps to omit character you want to omit from string. By default special characters like "_", "-","."," " are treated like word separator and treated accordingly by default and you don't have to worry about it.
+
+```go
+  pascalCase := stringy.New("ThisIsOne___messed up string. Can we Really pascal-case It ?##")
+  fmt.Println(pascalCase.PascalCase("?", "", "#", "")) // ThisIsOneMessedUpStringCanWeReallyPascalCaseIt
+```
+look how it omitted ?## from string. If you dont want to omit anything and since it returns plain strings and you cant actually cap all or lower case all camelcase string it's not required.
+
+```go
+  pascalCase := stringy.New("ThisIsOne___messed up string. Can we Really camel-case It ?##")
+  fmt.Println(pascalCase.PascalCase()) // ThisIsOneMessedUpStringCanWeReallyCamelCaseIt?##
 ```
 
 

--- a/example/main.go
+++ b/example/main.go
@@ -26,7 +26,7 @@ func main() {
 	fmt.Println(snakeCase.SnakeCase("?", "").ToLower())
 
 	camelCase := stringy.New("ThisIsOne___messed up string. Can we Really camel-case It ?##")
-	fmt.Println(camelCase.CamelCase("?", "", "#", ""))
+	fmt.Println(camelCase.CamelCase("?", "", "#", "").Get())
 
 	delimiterString := stringy.New("ThisIsOne___messed up string. Can we Really delimeter-case It?")
 	fmt.Println(delimiterString.Delimited("?").Get())
@@ -58,7 +58,7 @@ func main() {
 	fmt.Println(surroundStr.Surround("-"))
 
 	str := stringy.New("hello__man how-Are you??")
-	result := str.CamelCase("?", "")
+	result := str.CamelCase("?", "").Get()
 	fmt.Println(result) // HelloManHowAreYou
 
 	snakeStr := str.SnakeCase("?", "")

--- a/stringy.go
+++ b/stringy.go
@@ -21,7 +21,8 @@ type StringManipulation interface {
 	Acronym() StringManipulation
 	Between(start, end string) StringManipulation
 	Boolean() bool
-	CamelCase(rule ...string) string
+	PascalCase(rule ...string) StringManipulation
+	CamelCase(rule ...string) StringManipulation
 	ContainsAll(check ...string) bool
 	Delimited(delimiter string, rule ...string) StringManipulation
 	First(length int) string
@@ -112,10 +113,11 @@ func (i *input) Boolean() bool {
 // CamelCase is variadic function which takes one Param rule i.e slice of strings and it returns
 // input type string in camel case form and rule helps to omit character you want to omit from string.
 // By default special characters like "_", "-","."," " are l\treated like word separator and treated
-// accordingly by default and you dont have to worry about it
+// accordingly by default and you don't have to worry about it
+// First letter will be lowercase.
 // Example input: hello user
-// Result : HelloUser
-func (i *input) CamelCase(rule ...string) string {
+// Result : helloUser
+func (i *input) CamelCase(rule ...string) StringManipulation {
 	input := getInput(*i)
 	// removing excess space
 	wordArray := caseHelper(input, true, rule...)
@@ -126,7 +128,25 @@ func (i *input) CamelCase(rule ...string) string {
 			wordArray[i] = ucfirst(word)
 		}
 	}
-	return strings.Join(wordArray, "")
+	i.Result = strings.Join(wordArray, "")
+	return i
+}
+
+// PascalCase is variadic function which takes one Param rule i.e slice of strings and it returns
+// input type string in camel case form and rule helps to omit character you want to omit from string.
+// By default special characters like "_", "-","."," " are l\treated like word separator and treated
+// accordingly by default and you don't have to worry about it
+// Example input: hello user
+// Result : HelloUser
+func (i *input) PascalCase(rule ...string) StringManipulation {
+	input := getInput(*i)
+	// removing excess space
+	wordArray := caseHelper(input, true, rule...)
+	for i, word := range wordArray {
+		wordArray[i] = ucfirst(word)
+	}
+	i.Result = strings.Join(wordArray, "")
+	return i
 }
 
 // ContainsAll is variadic function which takes slice of strings as param and checks if they are present

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -77,16 +77,16 @@ func TestInput_BooleanError(t *testing.T) {
 
 func TestInput_CamelCase(t *testing.T) {
 	str := New("Camel case this_complicated__string%%")
-	val := str.CamelCase("%", "")
-	if val != "camelCaseThisComplicatedString" {
+	against := "camelCaseThisComplicatedString"
+	if val := str.CamelCase("%", "").Get(); val != against {
 		t.Errorf("Expected: to be %s but got: %s", "camelCaseThisComplicatedString", val)
 	}
 }
 
 func TestInput_CamelCaseNoRule(t *testing.T) {
 	str := New("Camel case this_complicated__string%%")
-	val := str.CamelCase()
-	if val != "camelCaseThisComplicatedString%%" {
+	against := "camelCaseThisComplicatedString%%"
+	if val := str.CamelCase().Get(); val != against {
 		t.Errorf("Expected: to be %s but got: %s", "camelCaseThisComplicatedString", val)
 	}
 }
@@ -98,10 +98,30 @@ func TestInput_CamelCaseOddRuleError(t *testing.T) {
 		}
 	}()
 	str := New("Camel case this_complicated__string%%")
-	val := str.CamelCase("%")
-
-	if val != "camelCaseThisComplicatedString%%" {
+	against := "camelCaseThisComplicatedString%%"
+	if val := str.CamelCase("%").Get(); val != against {
 		t.Errorf("Expected: to be %s but got: %s", "camelCaseThisComplicatedString", val)
+	}
+}
+
+func TestInput_PascalCaseNoRule(t *testing.T) {
+	str := New("pascal case this_complicated__string%%")
+	against := "PascalCaseThisComplicatedString%%"
+	if val := str.PascalCase().Get(); val != against {
+		t.Errorf("Expected: to be %s but got: %s", "PascalCaseThisComplicatedString", val)
+	}
+}
+
+func TestInput_PascalCaseOddRuleError(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("Error expected")
+		}
+	}()
+	str := New("pascal case this_complicated__string%%")
+	against := "PascalCaseThisComplicatedString%%"
+	if val := str.PascalCase("%").Get(); val != against {
+		t.Errorf("Expected: to be %s but got: %s", "PascalCaseThisComplicatedString", val)
 	}
 }
 


### PR DESCRIPTION
# Description

Two small changes:
- Changing CamelCase signature for consistency with SnakeCase, ...
- Adding missed PascalCase that was lost when fixed CamelCase in previous commits.
- Updating wrong comments in CamelCase.

Fixes #24 

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

- Same as Camel Case, but checking first letter to be upper case.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules