### PR TITLE
There are cases where you want the delimiter to be a space

### DIFF
--- a/stringy.go
+++ b/stringy.go
@@ -169,7 +169,7 @@ func (i *input) ContainsAll(check ...string) bool {
 // by default and you dont have to worry about it.
 func (i *input) Delimited(delimiter string, rule ...string) StringManipulation {
 	input := getInput(*i)
-	if strings.TrimSpace(delimiter) == "" {
+	if strings.TrimSpace(delimiter) == "" && delimiter != " " {
 		delimiter = "."
 	}
 	wordArray := caseHelper(input, false, rule...)


### PR DESCRIPTION
I figure that if the user is just passing in a single " " then that would match that case. However it don't handle the case of multiple `"  "` being intentional -- I'm not sure how you would want to handle this.

Perhaps, if the change should be on 173?

# Description

When using this I found a case where I wanted a ' ' delimiter.

Fixes n/a

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

This has not been testing being trivial and expecting push back.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules