### PR TITLE
Replace Split() with Fields() in Title() #30

### DIFF
--- a/stringy.go
+++ b/stringy.go
@@ -230,7 +230,7 @@ func (i *input) LcFirst() string {
 
 // Lines returns slice of strings by removing white space characters
 func (i *input) Lines() []string {
-	input := getInput(*i) 
+	input := getInput(*i)
 	result := matchWordRegexp.ReplaceAllString(input, " ")
 	return strings.Fields(strings.TrimSpace(result))
 }
@@ -363,7 +363,7 @@ func (i *input) ToLower() (result string) {
 // it can be chained on function which return StringManipulation interface
 func (i *input) Title() (result string) {
 	input := getInput(*i)
-	wordArray := strings.Split(input, " ")
+	wordArray := strings.Fields(input)
 	for i, word := range wordArray {
 		wordArray[i] = strings.ToUpper(string(word[0])) + strings.ToLower(word[1:])
 	}

--- a/stringy_test.go
+++ b/stringy_test.go
@@ -313,10 +313,69 @@ func TestInput_TeaseEmpty(t *testing.T) {
 }
 
 func TestInput_Title(t *testing.T) {
-	str := New("this is just AN eXample")
-	against := "This Is Just An Example"
-	if val := str.Title(); val != against {
-		t.Errorf("Expected: to be %s but got: %s", against, val)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "basic title case",
+			input: "this is just AN eXample",
+			want:  "This Is Just An Example",
+		},
+		{
+			name:  "multiple spaces",
+			input: "hello    world",
+			want:  "Hello World",
+		},
+		{
+			name:  "tabs and spaces",
+			input: "hello\t\t\tworld ",
+			want:  "Hello World",
+		},
+		{
+			name:  "newlines",
+			input: "hello\nworld",
+			want:  "Hello World",
+		},
+		{
+			name:  "mixed whitespace",
+			input: "hello \t\n world",
+			want:  "Hello World",
+		},
+		{
+			name:  "leading and trailing whitespace",
+			input: "  hello world  ",
+			want:  "Hello World",
+		},
+		{
+			name:  "single word",
+			input: "hello",
+			want:  "Hello",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "only whitespace",
+			input: "   \t\n  ",
+			want:  "",
+		},
+		{
+			name:  "special characters",
+			input: "hello-world",
+			want:  "Hello-world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.input).Title(); got != tt.want {
+				t.Errorf("Title() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Description

Fields() does a better job while splitting strings on a white space as mentioned by Go. 
> Fields splits the string s around each instance of one or more consecutive white space characters, as defined by [unicode.IsSpace](https://pkg.go.dev/unicode#IsSpace), returning a slice of substrings of s or an empty slice if s contains only white space.

Fixes # (issue)
#30 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a good set of unit tests to take account for different types of inputs.

```
Running tool: /opt/homebrew/bin/go test -timeout 30s ........

ok  	github.com/gobeam/stringy	0.182s	coverage: 100.0% of statements
```
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes